### PR TITLE
feature: adds ability to clear all notes in settings

### DIFF
--- a/app/src/main/java/com/example/learning3/app/NotesApp.kt
+++ b/app/src/main/java/com/example/learning3/app/NotesApp.kt
@@ -69,7 +69,8 @@ fun NotesApp(viewModel: NotesViewModel) {
         }
         composable(Screen.Settings.route) {
             SettingsScreen(
-                navController = navController
+                navController = navController,
+                onEvent = viewModel::onEvent
             )
         }
         composable(Screen.About.route) {

--- a/app/src/main/java/com/example/learning3/data/NoteDao.kt
+++ b/app/src/main/java/com/example/learning3/data/NoteDao.kt
@@ -20,4 +20,7 @@ interface NoteDao {
 
     @Query("SELECT * FROM note WHERE note.title LIKE ('%' || :query || '%') OR note.content LIKE ('%' || :query || '%')")
     fun getNotesFromQuery(query: String): Flow<List<Note>>
+
+    @Query("DELETE FROM note")
+    fun removeAllNotes()
 }

--- a/app/src/main/java/com/example/learning3/data/NoteDao.kt
+++ b/app/src/main/java/com/example/learning3/data/NoteDao.kt
@@ -22,5 +22,5 @@ interface NoteDao {
     fun getNotesFromQuery(query: String): Flow<List<Note>>
 
     @Query("DELETE FROM note")
-    fun removeAllNotes()
+    fun clearAllNotes()
 }

--- a/app/src/main/java/com/example/learning3/events/NoteEvent.kt
+++ b/app/src/main/java/com/example/learning3/events/NoteEvent.kt
@@ -4,6 +4,7 @@ import com.example.learning3.data.Note
 
 sealed interface NoteEvent {
     object SaveNote: NoteEvent
+    object ClearAllNotes: NoteEvent
     // data class SaveEditedNote(val note: Note): NoteEvent
     data class SetTitle(val title: String): NoteEvent
     data class SetContent(val content: String): NoteEvent

--- a/app/src/main/java/com/example/learning3/ui/screens/NotesScreen.kt
+++ b/app/src/main/java/com/example/learning3/ui/screens/NotesScreen.kt
@@ -96,6 +96,7 @@ fun NotesScreen(
             ExtendedFloatingActionButton(
                 onClick = {
                     navController.navigate(Screen.AddNote.route)
+                    onEvent(NoteEvent.SetSearchQuery(""))
                 },
                 containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                 contentColor = MaterialTheme.colorScheme.onTertiaryContainer

--- a/app/src/main/java/com/example/learning3/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/learning3/ui/screens/SettingsScreen.kt
@@ -76,7 +76,7 @@ fun SettingsScreen(
             bodyText = "All notes will be deleted permanently",
             onDismissRequest = { showDeleteDialog = false },
             onConfirmButtonClick = {
-                onEvent(NoteEvent.DeleteAllNotes)
+                onEvent(NoteEvent.ClearAllNotes)
                 showDeleteDialog = false
             },
             onDismissButtonClick = {

--- a/app/src/main/java/com/example/learning3/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/learning3/ui/screens/SettingsScreen.kt
@@ -1,9 +1,7 @@
 package com.example.learning3.ui.screens
 
-import android.widget.ToggleButton
-import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -19,17 +16,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LargeTopAppBar
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemColors
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -37,7 +29,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -48,33 +39,52 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.example.learning3.R
 import com.example.learning3.StoreThemePrefs
+import com.example.learning3.composables.DeleteDialog
 import com.example.learning3.composables.SettingsListItem
 import com.example.learning3.data.DarkThemeConfig
-import com.example.learning3.navigation.Screen
-import kotlinx.coroutines.coroutineScope
+import com.example.learning3.events.NoteEvent
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     navController: NavController,
+    onEvent: (NoteEvent) -> Unit
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val dataStore = StoreThemePrefs(context)
     var useDynamicThemeChecked by remember { mutableStateOf(true) }
     var themeModeExpanded by remember { mutableStateOf(false) }
-    val themeModeOptions = listOf<String>(
+    val themeModeOptions = listOf(
         "AUTO",
         "LIGHT",
         "DARK"
     )
-    var selectedOptionText by remember { mutableStateOf(themeModeOptions[0])}
+    var selectedOptionText by remember { mutableStateOf(themeModeOptions[0]) }
+
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        DeleteDialog(
+            titleText = "Confirm deletion?",
+            bodyText = "All notes will be deleted permanently",
+            onDismissRequest = { showDeleteDialog = false },
+            onConfirmButtonClick = {
+                onEvent(NoteEvent.DeleteAllNotes)
+                showDeleteDialog = false
+            },
+            onDismissButtonClick = {
+                showDeleteDialog = false
+            }
+        )
+    }
+
     Scaffold(
         containerColor = MaterialTheme.colorScheme.inverseOnSurface,
         contentColor = MaterialTheme.colorScheme.inverseSurface,
@@ -92,7 +102,7 @@ fun SettingsScreen(
                             navController.popBackStack()
                         }
                     ) {
-                        Icon(Icons.Default.ArrowBack,contentDescription = "Back")
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
                 }
             )
@@ -115,7 +125,7 @@ fun SettingsScreen(
                     .padding(top = 48.dp)
             )
             SettingsListItem(
-                title = "Dynamic theme",
+                title = "Dynamic Theme",
                 trailingContent = {
                     Switch(
                         checked = dataStore.isDynamicThemeEnabled.collectAsState(initial = true).value,
@@ -130,7 +140,7 @@ fun SettingsScreen(
             )
             if (!dataStore.isDynamicThemeEnabled.collectAsState(initial = true).value) {
                 SettingsListItem(
-                    title = "Theme mode",
+                    title = "Theme Mode",
                     trailingContent = {
                         MaterialTheme(
                             shapes = MaterialTheme.shapes.copy(
@@ -165,12 +175,14 @@ fun SettingsScreen(
                                     expanded = themeModeExpanded,
                                     onDismissRequest = { themeModeExpanded = false }
                                 ) {
-                                    themeModeOptions.forEach{
+                                    themeModeOptions.forEach {
                                         DropdownMenuItem(
-                                            text = { Text(
-                                                it,
-                                                style = MaterialTheme.typography.bodyLarge
-                                            ) },
+                                            text = {
+                                                Text(
+                                                    it,
+                                                    style = MaterialTheme.typography.bodyLarge
+                                                )
+                                            },
                                             onClick = {
                                                 selectedOptionText = it
                                                 scope.launch {
@@ -299,6 +311,19 @@ fun SettingsScreen(
                     Spacer(modifier = Modifier.width(24.dp))
                 }
             }
+            SettingsListItem(
+                title = "Clear All Notes",
+                trailingContent = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.baseline_delete_forever_40),
+                        contentDescription = "Clear All Notes",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.clickable {
+                            showDeleteDialog = true
+                        }
+                    )
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/learning3/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/example/learning3/viewmodel/NotesViewModel.kt
@@ -6,12 +6,14 @@ import com.example.learning3.data.Note
 import com.example.learning3.data.NoteDao
 import com.example.learning3.events.NoteEvent
 import com.example.learning3.ui.state.NoteState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 
 class NotesViewModel(private val noteDao: NoteDao) : ViewModel() {
@@ -43,6 +45,13 @@ class NotesViewModel(private val noteDao: NoteDao) : ViewModel() {
             is NoteEvent.DeleteNote -> {
                 viewModelScope.launch {
                     noteDao.deleteNote(event.note)
+                }
+            }
+            is NoteEvent.DeleteAllNotes -> {
+                viewModelScope.launch {
+                    withContext(Dispatchers.IO) {
+                        noteDao.removeAllNotes()
+                    }
                 }
             }
             NoteEvent.SaveNote -> {

--- a/app/src/main/java/com/example/learning3/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/example/learning3/viewmodel/NotesViewModel.kt
@@ -47,10 +47,10 @@ class NotesViewModel(private val noteDao: NoteDao) : ViewModel() {
                     noteDao.deleteNote(event.note)
                 }
             }
-            is NoteEvent.DeleteAllNotes -> {
+            is NoteEvent.ClearAllNotes -> {
                 viewModelScope.launch {
                     withContext(Dispatchers.IO) {
-                        noteDao.removeAllNotes()
+                        noteDao.clearAllNotes()
                     }
                 }
             }

--- a/app/src/main/res/drawable/baseline_delete_forever_40.xml
+++ b/app/src/main/res/drawable/baseline_delete_forever_40.xml
@@ -1,0 +1,5 @@
+<vector android:height="40dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="40dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM8.46,11.88l1.41,-1.41L12,12.59l2.12,-2.12 1.41,1.41L13.41,14l2.12,2.12 -1.41,1.41L12,15.41l-2.12,2.12 -1.41,-1.41L10.59,14l-2.13,-2.12zM15.5,4l-1,-1h-5l-1,1L5,4v2h14L19,4z"/>
+</vector>


### PR DESCRIPTION
This PR adds the ability to clear all notes in Settings. All warnings in visited classes have been cleared. Lastly, when user pushes `Add Note` on NotesScreen, the search bar text is set to empty string. This is to prevent a user entering text to search, adding a new note, and being returned to old notes based from the previous search query.