### PR TITLE
adds animations to notes and settings screen

### DIFF
--- a/app/src/main/java/com/example/learning3/ui/screens/NotesScreen.kt
+++ b/app/src/main/java/com/example/learning3/ui/screens/NotesScreen.kt
@@ -294,23 +294,15 @@ fun NotesScreen(
                     Text(text = "No Notes Saved")
                 }
             } else {
-                AnimatedVisibility(visible = showScreen) {
-                    NotesGrid(
-                        notes = state.notes.reversed(),
-                        onNoteClick = { note ->
-                            if (selectedNotes.size >= 1) {
-                                if (note.isSelected) {
-                                    onEvent(NoteEvent.DisableIsSelected(note))
-                                    selectedNotes.remove(note)
-                                } else {
-                                    onEvent(NoteEvent.EnableIsSelected(note))
-                                    selectedNotes.add(note)
-                                }
-                            } else {
-                                navController.navigate("${Screen.ViewNote.route}/${note.id}")
-                            }
-                        },
-                        onNoteLongClick = { note ->
+                val pinnedNotesList = state.notes.filter { note -> note.isPinned }
+                val unPinnedNotesList = state.notes.filter { note -> !note.isPinned }
+                val list = mutableListOf<Note>()
+                list.addAll(pinnedNotesList.reversed())
+                list.addAll(unPinnedNotesList.reversed())
+                NotesGrid(
+                    notes = list,
+                    onNoteClick = { note ->
+                        if (selectedNotes.size >= 1) {
                             if (note.isSelected) {
                                 onEvent(NoteEvent.DisableIsSelected(note))
                                 selectedNotes.remove(note)
@@ -318,9 +310,20 @@ fun NotesScreen(
                                 onEvent(NoteEvent.EnableIsSelected(note))
                                 selectedNotes.add(note)
                             }
+                        } else {
+                            navController.navigate("${Screen.ViewNote.route}/${note.id}")
                         }
-                    )
-                }
+                    },
+                    onNoteLongClick = { note ->
+                        if (note.isSelected) {
+                            onEvent(NoteEvent.DisableIsSelected(note))
+                            selectedNotes.remove(note)
+                        } else {
+                            onEvent(NoteEvent.EnableIsSelected(note))
+                            selectedNotes.add(note)
+                        }
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/learning3/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/learning3/ui/screens/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.learning3.ui.screens
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
@@ -48,6 +49,7 @@ import com.example.learning3.composables.DeleteDialog
 import com.example.learning3.composables.SettingsListItem
 import com.example.learning3.data.DarkThemeConfig
 import com.example.learning3.events.NoteEvent
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -69,6 +71,7 @@ fun SettingsScreen(
     var selectedOptionText by remember { mutableStateOf(themeModeOptions[0]) }
 
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var showDeleteCompleteIcon by remember { mutableStateOf(false) }
 
     if (showDeleteDialog) {
         DeleteDialog(
@@ -78,6 +81,11 @@ fun SettingsScreen(
             onConfirmButtonClick = {
                 onEvent(NoteEvent.ClearAllNotes)
                 showDeleteDialog = false
+                showDeleteCompleteIcon = true
+                scope.launch {
+                    delay(1500)
+                    showDeleteCompleteIcon = false
+                }
             },
             onDismissButtonClick = {
                 showDeleteDialog = false
@@ -198,7 +206,7 @@ fun SettingsScreen(
                     }
                 )
                 SettingsListItem(
-                    title = "Color scheme",
+                    title = "Color Scheme",
                     trailingContent = null
                 )
                 Row(
@@ -314,14 +322,25 @@ fun SettingsScreen(
             SettingsListItem(
                 title = "Clear All Notes",
                 trailingContent = {
-                    Icon(
-                        painter = painterResource(id = R.drawable.baseline_delete_forever_40),
-                        contentDescription = "Clear All Notes",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.clickable {
-                            showDeleteDialog = true
+                    Row {
+                        AnimatedVisibility(visible = showDeleteCompleteIcon) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.baseline_check_circle_24),
+                                contentDescription = "Deletion Complete",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
                         }
-                    )
+                        AnimatedVisibility(visible = !showDeleteCompleteIcon) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.baseline_delete_forever_40),
+                                contentDescription = "Clear All Notes",
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.clickable {
+                                    showDeleteDialog = true
+                                }
+                            )
+                        }
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/example/learning3/utilities/UtilityFunctions.kt
+++ b/app/src/main/java/com/example/learning3/utilities/UtilityFunctions.kt
@@ -2,6 +2,19 @@ package com.example.learning3.utilities
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -14,9 +27,59 @@ object UtilityFunctions {
         val instant = Instant.ofEpochMilli(lastModified)
         val localDateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
         val dateFormatter = DateTimeFormatter.ofPattern("MMM dd", Locale.getDefault())
+        return dateFormatter.format(localDateTime)
+    }
 
-        val formattedDate = dateFormatter.format(localDateTime)
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    fun LazyStaggeredGridState.calculateDelayAndEasing(index: Int, columnCount: Int): Pair<Int, Easing> {
+        val row = index / columnCount
+        val column = index % columnCount
+        val firstVisibleRow = remember { derivedStateOf { firstVisibleItemIndex } }
+        val visibleRows = layoutInfo.visibleItemsInfo.count()
+        val scrollingToBottom = firstVisibleRow.value < row
+        val isFirstLoad = visibleRows == 0
+        val rowDelay = 200 * when {
+            isFirstLoad -> row
+            scrollingToBottom -> 1
+            else -> 1 // scrolling to top
+        }
+        val scrollDirectionMultiplier = if (scrollingToBottom || isFirstLoad) 1 else -1
+        val columnDelay = column * 150 * scrollDirectionMultiplier
+        val easing = if (scrollingToBottom || isFirstLoad)
+            LinearOutSlowInEasing else FastOutSlowInEasing
+        return rowDelay + columnDelay to easing
+    }
 
-        return "$formattedDate"
+    private enum class State { PLACING, PLACED }
+
+    data class ScaleAndAlphaArgs(
+        val fromScale: Float,
+        val toScale: Float,
+        val fromAlpha: Float,
+        val toAlpha: Float
+    )
+
+    @Composable
+    fun scaleAndAlpha(
+        args: ScaleAndAlphaArgs,
+        animation: FiniteAnimationSpec<Float>
+    ): Pair<Float, Float> {
+        val transitionState =
+            remember { MutableTransitionState(State.PLACING).apply { targetState = State.PLACED } }
+        val transition = updateTransition(transitionState, label = "transition")
+        val alpha by transition.animateFloat(transitionSpec = { animation }, label = "alpha") { state ->
+            when (state) {
+                State.PLACING -> args.fromAlpha
+                State.PLACED -> args.toAlpha
+            }
+        }
+        val scale by transition.animateFloat(transitionSpec = { animation }, label = "scale") { state ->
+            when (state) {
+                State.PLACING -> args.fromScale
+                State.PLACED -> args.toScale
+            }
+        }
+        return alpha to scale
     }
 }

--- a/app/src/main/res/drawable/baseline_check_circle_24.xml
+++ b/app/src/main/res/drawable/baseline_check_circle_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="40dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="40dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>


### PR DESCRIPTION
`Note: Run this code on your own and play with the animations and see if you like it before merging this.`

Changes

- I've added animations to both notes screen and settings.

  - On the `notes screen`, each note has a (short) delayed appearance animation when initially loading the screen and scrolling.

  - In `settings`, when a user clears all notes, the trash icon is replaced with a check icon for 1.5 seconds and then back to the trash icon. This will indicate to the user that deletion was successful. 

- A `no notes saved` label has also been added and displayed instead of a blank notes screen.
- Shows newest notes first.
- Cleared all warnings in each modified class.